### PR TITLE
[build] 修复编译命令中的<tls_config.h>被shell解释为输入重定向的问题

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -202,7 +202,7 @@ cwd + '/mbedtls/library',
 cwd + '/ports/inc',
 ]
 
-CPPDEFINES = ['MBEDTLS_CONFIG_FILE=<tls_config.h>']
+CPPDEFINES = ['MBEDTLS_CONFIG_FILE=\\"tls_config.h\\"']
 
 group = DefineGroup('mbedtls', src, depend = ['PKG_USING_MBEDTLS'], CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved compatibility with header inclusion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->